### PR TITLE
Allow using a custom requests Session instance.

### DIFF
--- a/reppy/cache.py
+++ b/reppy/cache.py
@@ -40,6 +40,7 @@ class RobotsCache(object):
     def __init__(self, *args, **kwargs):
         # The provided args and kwargs are used when fetching robots.txt with
         # a `requests.get`
+        self.session = kwargs.pop('session', requests.Session())
         self.args = args
         self.kwargs = kwargs
         # A mapping of hostnames to their robots.txt rules
@@ -73,7 +74,7 @@ class RobotsCache(object):
             # First things first, fetch the thing
             robots_url = 'http://%s/robots.txt' % Utility.hostname(url)
             logger.debug('Fetching %s' % robots_url)
-            req = requests.get(robots_url, *args, **kwargs)
+            req = self.session.get(robots_url, *args, **kwargs)
             ttl = max(self.min_ttl, Utility.get_ttl(req.headers, self.default_ttl))
             # And now parse the thing and return it
             return parser.Rules(robots_url, req.status_code, req.content,


### PR DESCRIPTION
This is a simple way to allow for a lot of customization, like the user agent to use when fetching the robots file, without having to go the route of managing the cache manually.

Another thing I find stands in the way of reppy being a perfect drop-in-and-use-as-is API is that I have to pass the user agent into allowed() every time; it might be worth considering if it couldn't automatically use `self.session.headers['user-agent']`.
