### PR TITLE
Support Python 3.

### DIFF
--- a/reppy/__init__.py
+++ b/reppy/__init__.py
@@ -46,10 +46,18 @@ logger.setLevel(logging.ERROR)
 #####################################################
 # A couple utilities
 #####################################################
+import sys
 import re
 import time
-import urlparse
+try:
+    from urllib import parse as urlparse
+except ImportError:
+    # Python 2
+    import urlparse
 import dateutil.parser
+
+if sys.version_info[0] == 3:
+    long = int
 
 #####################################################
 # Import our exceptions at the global level

--- a/reppy/cache.py
+++ b/reppy/cache.py
@@ -28,6 +28,7 @@ import time
 import requests
 
 from . import parser, logger, exceptions, Utility
+from .parser import string_types
 
 
 class RobotsCache(object):
@@ -89,7 +90,7 @@ class RobotsCache(object):
     def allowed(self, url, agent):
         '''Check whether the provided url is allowed for the provided user
         agent. The agent may be a short or long version'''
-        if hasattr(url, '__iter__'):
+        if hasattr(url, '__iter__') and not isinstance(url, string_types):
             results = [self.allowed(u, agent) for u in url]
             return [u for u, allowed in zip(url, results) if allowed]
         return self.find(url, fetch_if_missing=True).allowed(
@@ -98,7 +99,7 @@ class RobotsCache(object):
     def disallowed(self, url, agent):
         '''Check whether the provided url is disallowed. Equivalent to:
             not obj.allowed(url, agent)'''
-        if hasattr(url, '__iter__'):
+        if hasattr(url, '__iter__') and not isinstance(url, string_types):
             results = [self.allowed(u, agent) for u in url]
             return [u for u, allowed in zip(url, results) if not allowed]
         return not self.allowed(url, agent)

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,17 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import sys
+dateutil_version = '>=2.0' if sys.version_info[0] == 3 else '==1.5'
 try:
     from setuptools import setup
     extra = {
-        'install_requires': ['python-dateutil==1.5', 'url', 'requests']
+        'install_requires': ['python-dateutil{}'.format(dateutil_version), 'url', 'requests']
     }
 except ImportError:
     from distutils.core import setup
     extra = {
-        'dependencies': ['python-dateutil==1.5', 'url', 'requests']
+        'dependencies': ['python-dateutil{}'.format(dateutil_version), 'url', 'requests']
     }
 
 setup(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,6 +5,12 @@
 http://www.robotstxt.org/norobots-rfc.txt'''
 
 import unittest
+import sys
+
+if sys.version_info[0] == 3:
+    # We cannot run these tests on Python 3 yet, because they rely
+    # on the asis module and gevent, both of which are not available.
+    raise unittest.SkipTest()
 
 # We need to monkey-path socket
 from gevent import monkey; monkey.patch_all()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -310,7 +310,7 @@ class TestParse(unittest.TestCase):
     def test_utf8_bom(self):
         '''If there's a utf-8 BOM, we should parse it as such'''
         import codecs
-        rules = self.parse(codecs.BOM_UTF8 + '''User-agent: foo
+        rules = self.parse(codecs.BOM_UTF8 + b'''User-agent: foo
             Allow: /foo
 
             User-agent: *
@@ -321,7 +321,7 @@ class TestParse(unittest.TestCase):
 
     def test_utf16_bom(self):
         '''If there's a utf-16 BOM, we should parse it as such'''
-        rules = self.parse('''User-agent: foo
+        rules = self.parse(b'''User-agent: foo
             Allow: /foo
 
             User-agent: *


### PR DESCRIPTION
I've tested this with Python 3.3, but below should work as well, and there shouldn't be anything in here limiting support on 2.x either.

Tests pass, except for test_cache, which depends on gevent/asis which is not available on 3, so those tests are skipped.
