### PR TITLE
Bumping version of python-dateutil to 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,17 +24,17 @@
 try:
     from setuptools import setup
     extra = {
-        'install_requires': ['python-dateutil==1.5', 'url', 'requests']
+        'install_requires': ['python-dateutil==2.2', 'url', 'requests']
     }
 except ImportError:
     from distutils.core import setup
     extra = {
-        'dependencies': ['python-dateutil==1.5', 'url', 'requests']
+        'dependencies': ['python-dateutil==2.2', 'url', 'requests']
     }
 
 setup(
     name             = 'reppy',
-    version          = '0.2.2',
+    version='0.2.3',
     description      = 'Replacement robots.txt Parser',
     long_description = '''Replaces the built-in robotsparser with a
 RFC-conformant implementation that supports modern robots.txt constructs like


### PR DESCRIPTION
python-dateutil 2.2 now works on Python2 and and 3.
All tests are passing

Signed-off-by: Philippe Ombredanne pombredanne@nexb.com
