### PR TITLE
Handle unencoded strings without chardet.

### DIFF
--- a/reppy/parser.py
+++ b/reppy/parser.py
@@ -167,6 +167,8 @@ class Rules(object):
                         text_type(codecs.BOM_UTF8, 'utf-8'))
                 elif content.startswith(codecs.BOM_UTF16):
                     content = content.decode('utf-16')
+                else:
+                    content = content.decode('utf-8', 'ignore')
             except UnicodeDecodeError:  # pragma: no cover
                 # This is a very rare and difficult-to-reproduce exception
                 logger.error('Too much garbage! Ignoring %s' % self.url)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -330,6 +330,17 @@ class TestParse(unittest.TestCase):
         self.assertTrue(rules.allowed('/foo', 'foo'))
         self.assertTrue(not rules.allowed('/foo', 'other'))
 
+    def test_ascii(self):
+         '''If we get bytes without encoding, we should parse it as such'''
+         rules = self.parse(b'''User-agent: foo
+             Allow: /foo
+
+             User-agent: *
+             Disallow: /foo
+         ''')
+         self.assertTrue(rules.allowed('/foo', 'foo'))
+         self.assertTrue(not rules.allowed('/foo', 'other'))
+
     def test_skip_line(self):
         '''If there is no colon in a line, then we must skip it'''
         rules = self.parse('''User-agent: foo


### PR DESCRIPTION
Revised proposal for handling unencoded strings based on discussion in https://github.com/seomoz/reppy/pull/16.
