### PR TITLE
OK, take 2, updated master.

### DIFF
--- a/reppy/cache.py
+++ b/reppy/cache.py
@@ -47,13 +47,13 @@ class RobotsCache(object):
         # A mapping of hostnames to their robots.txt rules
         self._cache = {}
 
-    def find(self, url, fetch_if_missing=False):
+    def find(self, url, fetch_if_missing=False, honor_ttl=True):
         '''Finds the rules associated with the particular url. Optionally, it
         can fetch the rules if they are missing.'''
         canonical = Utility.hostname(url)
         cached = self._cache.get(canonical)
         # If it's expired, we should get rid of it
-        if cached and cached.expired:
+        if honor_ttl and cached and cached.expired:
             del self._cache[canonical]
             cached = None
         # Should we fetch it if it's missing?

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -60,11 +60,13 @@ class TestCache(unittest.TestCase):
             old_ttl = self.robots.min_ttl
             self.robots.min_ttl = 0
             self.assertNotEqual(
-                self.robots.find('http://localhost:8080/foo', True), None)
-            # Now, it shouldn't be cached, so when we find it again, it should
-            # be missing (or at least, requiring a refetch)
+                self.robots.find('http://localhost:8080/foo', fetch_if_missing=True), None)
+            # If we ignore the TTL, it should still be there.
+            self.assertNotEqual(
+                self.robots.find('http://localhost:8080/foo', fetch_if_missing=False, honor_ttl=False), None)
+            # However, if we honor the TTL, it should be missing in the cache.
             self.assertEqual(
-                self.robots.find('http://localhost:8080/foo', False), None)
+                self.robots.find('http://localhost:8080/foo', fetch_if_missing=False), None)
             self.robots.min_ttl = old_ttl
 
     def test_clear(self):


### PR DESCRIPTION
Simple stuff: provide an honor_ttl option to fetch. Default is true, the legacy behavior. But there's now a way to request the cache always be used even if the data therein is stale.

Reason is I need to sometimes return "stale" information in a multithreaded crawler I'm writing -- in the case where multiple threads are waiting on the same robots.txt file, all waiting threads should get it, even if the server marks it pre-expired (as some servers do).