### PR TITLE
Added a new Utility to return a robots.txt URI

### DIFF
--- a/reppy/__init__.py
+++ b/reppy/__init__.py
@@ -70,6 +70,12 @@ class Utility(object):
     def hostname(url):
         '''Return a normalized, canonicalized version of the url's hostname'''
         return urlparse.urlparse(url).netloc
+    
+    @staticmethod
+    def roboturl(url):
+        '''Return a normalized uri to the robots.txt'''
+        parsed = urlparse.urlparse(url)
+        return '%s://%s/robots.txt' % (parsed.scheme, parsed.netloc)
 
     @staticmethod
     def short_user_agent(strng):

--- a/reppy/cache.py
+++ b/reppy/cache.py
@@ -73,7 +73,7 @@ class RobotsCache(object):
         '''
         try:
             # First things first, fetch the thing
-            robots_url = 'http://%s/robots.txt' % Utility.hostname(url)
+            robots_url = Utility.roboturl(url)
             logger.debug('Fetching %s' % robots_url)
             req = self.session.get(robots_url, *args, **kwargs)
             ttl = max(self.min_ttl, Utility.get_ttl(req.headers, self.default_ttl))


### PR DESCRIPTION
Was running into a problem where the Session object just hangs when I'm looking for a robots.txt file that behind a https://... URL.  Simple, quick solution is to just check what the scheme is, and use that.  Not sure if this is helpful for anyone besides me.