### PR TITLE
BIG-3642 - Be robust against malformed crawl delays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
+.PHONY: test
+test:
+	nosetests --with-coverage
+
+install:
+	python setup.py install
+
+dev-requirements:
+	pip freeze | grep -v -e reppy > dev-requirements.txt
+
+dev-requirements-py3:
+	pip freeze | grep -v -e reppy > dev-requirements-py3.txt
+
 clean:
-	# Remove the build
-	sudo rm -rf build dist
-	# And all of our pyc files
-	find . -name '*.pyc' | xargs -n 100 rm
-	# And lastly, .coverage files
-	find . -name .coverage | xargs rm
-
-nose:
-	nosetests --exe --cover-package=reppy --with-coverage --cover-branches -v
-
-test: nose
+	rm -rf build dist *.egg-info
+	find . -name '*.pyc' | xargs --no-run-if-empty rm

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,3 +1,12 @@
--r requirements.txt
-nose
-coverage
+colorama==0.3.7
+coverage==4.0.3
+mock==2.0.0
+nose==1.3.7
+pbr==1.9.1
+publicsuffix==1.1.0
+python-dateutil==2.5.3
+python-termstyle==0.1.10
+rednose==1.1.1
+requests==2.10.0
+six==1.10.0
+url==0.1.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,18 @@
--r requirements.txt
-git+https://github.com/seomoz/asis
-nose
-coverage
-mock
+asis==0.2.3
+bottle==0.12.9
+colorama==0.3.7
+coverage==4.0.3
+funcsigs==1.0.2
+gevent==1.1.1
+greenlet==0.4.9
+mock==2.0.0
+nose==1.3.7
+pbr==1.9.1
+publicsuffix==1.1.0
+python-dateutil==2.5.3
+python-termstyle==0.1.10
+rednose==1.1.1
+requests==2.10.0
+six==1.10.0
+url==0.1.7
+wheel==0.24.0

--- a/reppy/parser.py
+++ b/reppy/parser.py
@@ -228,7 +228,10 @@ class Rules(object):
                 cur.allowances.append(
                     (len(val), self._regex_rule(val), True))
             elif cur and key == 'crawl-delay':
-                cur.delay = float(val)
+                try:
+                    cur.delay = float(val)
+                except:
+                    logger.warn('Unable to parse crawl delay "%s" as float.', val)
             elif cur and key == 'sitemap':
                 self.sitemaps.append(val)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-url
-requests
-python-dateutil
+url==0.1.7
+requests==2.10.0
+python-dateutil==2.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[nosetests]
+verbosity=2
+rednose=1
+exe=1
+cover-package=reppy
+cover-branches=1
+#cover-min-percentage=100
+cover-inclusive=1
+cover-erase=1
+logging-clear-handlers=1

--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-try:
-    from setuptools import setup
-    extra = {
-        'install_requires': ['python-dateutil>=1.5, !=2.0', 'url', 'requests']
-    }
-except ImportError:
-    from distutils.core import setup
-    extra = {
-        'dependencies': ['python-dateutil>=1.5, !=2.0', 'url', 'requests']
-    }
+from setuptools import setup
 
 setup(
     name             = 'reppy',
@@ -47,17 +38,22 @@ Sitemaps, Allow, and Crawl-delay. Main features:
 - Automatic refetching basing on expiration
 ''',
     author           = 'Dan Lecocq',
-    author_email     = 'dan@seomoz.org',
+    author_email     = 'dan@moz.com',
     url              = 'http://github.com/seomoz/reppy',
-    packages         = ['reppy'],
     license          = 'MIT',
     platforms        = 'Posix; MacOS X',
-    test_suite       = 'tests.testReppy',
+    packages         = [
+        'reppy'
+    ],
+    install_requires = [
+        'python-dateutil>=1.5, !=2.0',
+        'url<0.2.0',
+        'requests'
+    ],
     classifiers      = [
         'License :: OSI Approved :: MIT License',
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'Topic :: Internet :: WWW/HTTP'],
-    **extra
+        'Topic :: Internet :: WWW/HTTP']
 )

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -975,5 +975,13 @@ class TestParse(unittest.TestCase):
         self.assertEqual('/foo/bar?a=b',
             Agent.extract_path('http://example.com/foo/bar?a=b'))
 
+    def test_malformed_crawl_delay(self):
+        '''Ignore crawl delays that are too malformed to parse.'''
+        rules = self.parse('''
+            User-agent: *
+            Crawl-delay: 
+            ''')
+        self.assertEqual(rules.delay('rogerbot'), None)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some `robots.txt`s are malformed, and we should be robust against that. In the case where there's a malformed crawl delay, we ignore that directive.

@lindseyreno @tammybailey 