### PR TITLE
Combine many asterisks into a single one when processing rules

### DIFF
--- a/reppy/parser.py
+++ b/reppy/parser.py
@@ -96,6 +96,7 @@ class Agent(object):
         else:
             return True
 
+RE_ASTERISK = re.compile(r'\*+')
 
 class Rules(object):
     '''A class that represents a set of agents, and can select them
@@ -149,6 +150,8 @@ class Rules(object):
         # '*' and '/'
         if rule and rule[0] != '/' and rule[0] != '*':
             rule = '/' + rule
+        # collapse many **** into a single one
+        rule = RE_ASTERISK.sub('*', rule)
         tmp = re.escape(unquote(rule.replace('%2f', '%252f')))
         return re.compile(tmp.replace('\*', '.*').replace('\$', '$'))
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -612,6 +612,13 @@ class TestParse(unittest.TestCase):
         self.assertTrue(not rules.allowed('/products/default.aspx', agent))
         self.assertTrue(not rules.allowed('/author/admin/feed/', agent))
 
+    def test_many_wildcards(self):
+        rules = self.parse('''
+            User-agent: *
+            Allow: /***************************************.css''')
+        agent = 'dotbot'
+        self.assertTrue(rules.allowed('/blog/a-really-long-url-string-that-takes-a-very-long-time-to-process-without-combining-many-asterisks', agent))
+
     def test_allow_edge_cases(self):
         rules = self.parse('''
             User-agent: *


### PR DESCRIPTION
At least one site includes a directive like `Allow: /***************************************.css`.  The current method for compiling into a regular expression includes all `*` and takes an impossibly long time to process.  This PR simply combines many consecutive asterisks into a single one before compiling the rule.