### PR TITLE
BIG-4047 - Use less `re`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	nosetests --with-coverage
+	nosetests --with-coverage tests
 
 install:
 	python setup.py install

--- a/bench.py
+++ b/bench.py
@@ -1,0 +1,34 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+
+from contextlib import contextmanager
+import sys
+import time
+
+from reppy.cache import RobotsCache
+from reppy.parser import Rules
+
+content = '''
+User-agent: '*'
+Allow: /
+'''
+
+cache = RobotsCache()
+cache.add(Rules('http://example.com/', 200, content, sys.maxint))
+
+@contextmanager
+def timer(count):
+    '''Time this block.'''
+    start = time.time()
+    try:
+        yield count
+    finally:
+        duration = time.time() - start
+        print('Total: %s' % duration)
+        print('  Avg: %s' % (duration / count))
+        print(' Rate: %s' % (count / duration))
+
+with timer(100000) as count:
+    for _ in xrange(count):
+        cache.allowed('http://example.com/page', 'agent')

--- a/reppy/__init__.py
+++ b/reppy/__init__.py
@@ -81,7 +81,10 @@ class Utility(object):
     def short_user_agent(strng):
         '''Return a default user agent string to match, based on strng. For
         example, for 'MyUserAgent/1.0', it will generate 'MyUserAgent' '''
-        return re.sub('(\S+?)(\/.+)?', r'\1', strng)
+        index = strng.find('/')
+        if index == -1:
+            return strng
+        return strng[0:index]
 
     @staticmethod
     def parse_time(strng):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 setup(
     name             = 'reppy',
-    version          = '0.3.3',
+    version          = '0.3.4',
     description      = 'Replacement robots.txt Parser',
     long_description = '''Replaces the built-in robotsparser with a
 RFC-conformant implementation that supports modern robots.txt constructs like


### PR DESCRIPTION
Initially the intent of this ticket was to replace the use of `urllib` with a preference for `url-py`, but it turns out:

- there were much more dominant factors (`re` use)
- `url-py` currently lacks python 3 support, which `reppy` currently maintains

I did try benchmarking the use of `url-py`, and depending on how we feel (or its future python 3 support), we could merge that later:

| Revision |    Functionality   | Average  | Rate / s | Speedup |
|----------|:------------------:|----------|----------|---------|
| 9d63a15e | -                  | 3.54e-05 | 28248.05 | 1       |
| 1e92f23a | remove hot-path re | 1.22e-05 | 81477.49 | 2.88    |
| 1a9eb085 | drop urlparse      | 1.03e-05 | 96156.62 | 3.4     |

@matt-peters -- I imagine you might be interested in this

@lindseyreno @arora-richa @b4hand 