### PR TITLE
Drop url-py as dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cachetools==2.0.0
-url==0.3.0
 requests==2.10.0
 six==1.10.0
 python-dateutil==2.5.3


### PR DESCRIPTION
It is no longer directly needed. Instead reppy depends on rep-cpp which depends directly on url-cpp rather than on url-py.