### PR TITLE
Fix circular dependency on reppy/robots.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ dev-requirements-py3:
 	pip freeze | grep -v -e reppy > dev-requirements-py3.txt
 
 clean:
-	rm -rf build dist *.egg-info
+	rm -rf build dist *.egg-info reppy/*.so
 	find . -name '*.pyc' | xargs --no-run-if-empty rm

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 test: reppy/robots.so
 	nosetests --with-coverage tests
 
-reppy/%.so: reppy/%.* reppy/rep-cpp/src/* reppy/rep-cpp/include/* reppy/rep-cpp/deps/url-cpp/include/* reppy/rep-cpp/deps/url-cpp/src/*
+reppy/%.so: reppy/%.py* reppy/rep-cpp/src/* reppy/rep-cpp/include/* reppy/rep-cpp/deps/url-cpp/include/* reppy/rep-cpp/deps/url-cpp/src/*
 	python setup.py build_ext --inplace
 
 install:


### PR DESCRIPTION
Previously, when rebuilding with `make`, it would report the following warning:
```
make: Circular reppy/robots.so <- reppy/robots.so dependency dropped.
```
This is because `reppy/robots.so` itself matches the pattern `reppy/%.*`, so by restricting the dependency to `reppy/%.py*`, it won't have a self-dependency.

Also, remove `reppy/*.so` during `make clean`.