### PR TITLE
Add new py3 version to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7-dev"
 
 install: pip install -r dev-requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ python:
   - "3.6"
   - "3.7-dev"
 
+matrix:
+  allow_failures:
+    - "3.7-dev"
+
 install: pip install -r dev-requirements.txt
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 matrix:
   allow_failures:
-    - "3.7-dev"
+    - python: "3.7-dev"
 
 install: pip install -r dev-requirements.txt
 


### PR DESCRIPTION
I noticed when submitting a PR for another project to add support
for respecting robots.txt files that reppy was not building under
python 3.7-dev and nightly builds.

To ensure proper visibility for coming versions, I am proposing
additional versions for the testing matrix.