### PR TITLE
Drop unused make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ install:
 dev-requirements:
 	pip freeze | grep -v -e reppy > dev-requirements.txt
 
-dev-requirements-py3:
-	pip freeze | grep -v -e reppy > dev-requirements-py3.txt
-
 clean:
 	rm -rf build dist *.egg-info reppy/*.so
 	find . -name '*.pyc' | xargs --no-run-if-empty rm


### PR DESCRIPTION
This is no longer required since 3e0e86d.