### PR TITLE
Log errors that happen when fetching from cache

### DIFF
--- a/reppy/cache/__init__.py
+++ b/reppy/cache/__init__.py
@@ -8,6 +8,7 @@ from cachetools import LRUCache
 
 from .policy import DefaultObjectPolicy, ReraiseExceptionPolicy
 from ..robots import Robots, AllowNone, Agent
+from .. import logger
 
 
 class ExpiringObject(object):
@@ -61,6 +62,7 @@ class BaseCache(object):
         try:
             return self.fetch(url)
         except BaseException as exc:
+            logger.exception('Reppy error on %s' % url)
             return self.cache_policy.exception(url, exc)
 
     def fetch(self, url):

--- a/reppy/cache/__init__.py
+++ b/reppy/cache/__init__.py
@@ -62,7 +62,7 @@ class BaseCache(object):
         try:
             return self.fetch(url)
         except BaseException as exc:
-            logger.exception('Reppy error on %s' % url)
+            logger.exception('Reppy cache fetch error on %s' % url)
             return self.cache_policy.exception(url, exc)
 
     def fetch(self, url):

--- a/tests/test_cache/test_cache.py
+++ b/tests/test_cache/test_cache.py
@@ -132,7 +132,7 @@ class TestAgentCache(unittest.TestCase):
             self.cache.get('http://does-not-resolve/')
 
             expected_err = reppy.exceptions.ConnectionException
-            expected_msg = 'Reppy error on http://does-not-resolve/robots.txt'
+            expected_msg = 'Reppy cache fetch error on http://does-not-resolve/robots.txt'
             self.assertIn((expected_err, expected_msg), logs)
 
     def test_agent_allowed(self):


### PR DESCRIPTION
This would have made my life easier when debug two recent issues. I'm not 100% sure this is OK to do in all cases but it seems reasonable. In our project which uses reppy, we get the error that is returned and reraise it, but this erases stack trace information from the original error.

I guess another option would be to log it with `logging.debug(msg, exc_info=True)` to log with the "debug" log level.