### PR TITLE
Rewrite functionality removed from cachetools 3

### DIFF
--- a/reppy/cache/__init__.py
+++ b/reppy/cache/__init__.py
@@ -37,6 +37,19 @@ class ExpiringObject(object):
             return self.obj
 
 
+class LRUCacheWithMissingHandler(LRUCache):
+    '''Same as LRUCache but we can pass in a "missing" handler which will
+    be called if the key is missing. The result is then stored in the
+    cache. cachetools's LRUCache used to support this functionality, but it
+    was inexplicably removed in cachetools 3.0.0.'''
+    def __init__(self, maxsize, missing):
+        LRUCache.__init__(self, maxsize=maxsize)
+        self._missing_handler = missing
+
+    def __missing__(self, key):
+        self[key] = self._missing_handler(key)
+        return self[key]
+
 class BaseCache(object):
     '''A base cache class.'''
 
@@ -46,7 +59,7 @@ class BaseCache(object):
     def __init__(self, capacity, cache_policy=None, ttl_policy=None, *args, **kwargs):
         self.cache_policy = cache_policy or self.DEFAULT_CACHE_POLICY
         self.ttl_policy = ttl_policy or self.DEFAULT_TTL_POLICY
-        self.cache = LRUCache(maxsize=capacity, missing=self.missing)
+        self.cache = LRUCacheWithMissingHandler(maxsize=capacity, missing=self.missing)
         self.args = args
         self.kwargs = kwargs
 

--- a/reppy/cache/__init__.py
+++ b/reppy/cache/__init__.py
@@ -37,19 +37,6 @@ class ExpiringObject(object):
             return self.obj
 
 
-class LRUCacheWithMissingHandler(LRUCache):
-    '''Same as LRUCache but we can pass in a "missing" handler which will
-    be called if the key is missing. The result is then stored in the
-    cache. cachetools's LRUCache used to support this functionality, but it
-    was inexplicably removed in cachetools 3.0.0.'''
-    def __init__(self, maxsize, missing):
-        LRUCache.__init__(self, maxsize=maxsize)
-        self._missing_handler = missing
-
-    def __missing__(self, key):
-        self[key] = self._missing_handler(key)
-        return self[key]
-
 class BaseCache(object):
     '''A base cache class.'''
 
@@ -59,13 +46,16 @@ class BaseCache(object):
     def __init__(self, capacity, cache_policy=None, ttl_policy=None, *args, **kwargs):
         self.cache_policy = cache_policy or self.DEFAULT_CACHE_POLICY
         self.ttl_policy = ttl_policy or self.DEFAULT_TTL_POLICY
-        self.cache = LRUCacheWithMissingHandler(maxsize=capacity, missing=self.missing)
+        self.cache = LRUCache(maxsize=capacity)
         self.args = args
         self.kwargs = kwargs
 
     def get(self, url):
         '''Get the entity that corresponds to URL.'''
-        return self.cache[Robots.robots_url(url)].get()
+        robots_url = Robots.robots_url(url)
+        if robots_url not in self.cache:
+            self.cache[robots_url] = ExpiringObject(partial(self.factory, robots_url))
+        return self.cache[robots_url].get()
 
     def factory(self, url):
         '''
@@ -81,10 +71,6 @@ class BaseCache(object):
     def fetch(self, url):
         '''Return (expiration, obj) corresponding to provided url.'''
         raise NotImplementedError('BaseCache does not implement fetch.')
-
-    def missing(self, url):
-        '''Invoked on cache misses.'''
-        return ExpiringObject(partial(self.factory, url))
 
 
 class RobotsCache(BaseCache):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cachetools==2.0.0
+cachetools==3.0.0
 requests==2.10.0
 six==1.10.0
 python-dateutil==2.5.3

--- a/tests/test_cache/test_cache.py
+++ b/tests/test_cache/test_cache.py
@@ -50,6 +50,42 @@ class TestBaseCache(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             cache.BaseCache(10).fetch('http://example.com/robots.txt')
 
+class TestBaseCacheLRUCacheWithMissingHandler(unittest.TestCase):
+    '''Tests LRUCacheWithMissingHandler'''
+
+    def calls_the_missing_function(self):
+        # missing ...
+        def missing(item):
+            return item + item
+        cache = cache.LRUCacheWithMissingHandler(maxsize=123, missing=missing)
+        self.assertEqual(cache[5], 10)
+        self.assertEqual(cache[6], 12)
+        self.assertEqual(5 in cache, True)
+        self.assertEqual(6 in cache, True)
+
+    def caches_the_result_of_the_missing_function(self):
+        calls = []
+        def missing(item):
+            calls.append(item)
+            return item * item
+        cache = cache.LRUCacheWithMissingHandler(maxsize=123, missing=missing)
+        self.assertEqual(cache[5], 10)
+        self.assertEqual(cache[6], 12)
+        self.assertEqual(cache[6], 12)
+        self.assertEqual(cache[5], 10)
+        self.assertEqual(calls, [5, 6])
+
+    def fills_up_capactity(self):
+        def missing(item):
+            return item + item
+        cache = cache.LRUCacheWithMissingHandler(maxsize=2, missing=missing)
+        self.assertEqual(cache[5], 10)
+        self.assertEqual(cache[6], 12)
+        self.assertEqual(cache[7], 14)
+        self.assertEqual(5 in cache, False)
+        self.assertEqual(6 in cache, True)
+        self.assertEqual(7 in cache, True)
+
 
 class TestRobotsCache(unittest.TestCase):
     '''Tests about RobotsCache.'''

--- a/tests/test_cache/test_cache.py
+++ b/tests/test_cache/test_cache.py
@@ -50,41 +50,6 @@ class TestBaseCache(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             cache.BaseCache(10).fetch('http://example.com/robots.txt')
 
-class TestBaseCacheLRUCacheWithMissingHandler(unittest.TestCase):
-    '''Tests LRUCacheWithMissingHandler'''
-
-    def calls_the_missing_function(self):
-        def missing(item):
-            return item + item
-        cache = cache.LRUCacheWithMissingHandler(maxsize=123, missing=missing)
-        self.assertEqual(cache[5], 10)
-        self.assertEqual(cache[6], 12)
-        self.assertEqual(5 in cache, True)
-        self.assertEqual(6 in cache, True)
-
-    def caches_the_result_of_the_missing_function(self):
-        calls = []
-        def missing(item):
-            calls.append(item)
-            return item * item
-        cache = cache.LRUCacheWithMissingHandler(maxsize=123, missing=missing)
-        self.assertEqual(cache[5], 10)
-        self.assertEqual(cache[6], 12)
-        self.assertEqual(cache[6], 12)
-        self.assertEqual(cache[5], 10)
-        self.assertEqual(calls, [5, 6])
-
-    def fills_up_capactity(self):
-        def missing(item):
-            return item + item
-        cache = cache.LRUCacheWithMissingHandler(maxsize=2, missing=missing)
-        self.assertEqual(cache[5], 10)
-        self.assertEqual(cache[6], 12)
-        self.assertEqual(cache[7], 14)
-        self.assertEqual(5 in cache, False)
-        self.assertEqual(6 in cache, True)
-        self.assertEqual(7 in cache, True)
-
 
 class TestRobotsCache(unittest.TestCase):
     '''Tests about RobotsCache.'''

--- a/tests/test_cache/test_cache.py
+++ b/tests/test_cache/test_cache.py
@@ -54,7 +54,6 @@ class TestBaseCacheLRUCacheWithMissingHandler(unittest.TestCase):
     '''Tests LRUCacheWithMissingHandler'''
 
     def calls_the_missing_function(self):
-        # missing ...
         def missing(item):
             return item + item
         cache = cache.LRUCacheWithMissingHandler(maxsize=123, missing=missing)


### PR DESCRIPTION
For some reason, cachetools version 3 (released on 2018-11-04) removed
the ability to pass in a `missing` function; apparently this made
the implementation cleaner (see tkem/cachetools#58). Unfortunately we
use this functionality here.

Rather than require version 2 of cachetools, I thought it would be
better to allow reppy to be used with the new version. ~~Unfortunately,
that means a reimplementation of pretty much exactly what was removed
from cachetools.~~

I discovered this because we have a project which uses reppy and its tests
suddenly broke, because pip automatically installed the newer version of
cachetools.