### PR TITLE
release 0.4.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ ext_modules = [
 
 setup(
     name='reppy',
-    version='0.4.11',
+    version='0.4.12',
     description='Replacement robots.txt Parser',
     long_description='''Replaces the built-in robotsparser with a
 RFC-conformant implementation that supports modern robots.txt constructs like


### PR DESCRIPTION
I consider cachetools breaking current/old reppy to be
enough cause to bump the version of reppy. For background,
that was fixed in reppy here:

https://github.com/seomoz/reppy/pull/103