### PR TITLE
Fix sitemaps api

### DIFF
--- a/reppy/robots.pyx
+++ b/reppy/robots.pyx
@@ -168,7 +168,7 @@ cdef class Robots:
     @property
     def sitemaps(self):
         '''Get all the sitemaps in this robots.txt.'''
-        return map(as_string, self.robots.sitemaps())
+        return list(map(as_string, self.robots.sitemaps()))
 
     def allowed(self, path, name):
         '''Is the provided path allowed for the provided agent?'''

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -132,7 +132,7 @@ class RobotsTest(unittest.TestCase):
             Sitemap: http://a.com/sitemap.xml
             Sitemap: http://b.com/sitemap.xml
         ''')
-        self.assertEqual(list(robot.sitemaps), [
+        self.assertEqual(robot.sitemaps, [
             'http://a.com/sitemap.xml', 'http://b.com/sitemap.xml'
         ])
 
@@ -148,7 +148,7 @@ class RobotsTest(unittest.TestCase):
     def test_empty(self):
         '''Makes sure we can parse an empty robots.txt'''
         robot = robots.Robots.parse('http://example.com/robots.txt', '')
-        self.assertEqual(list(robot.sitemaps), [])
+        self.assertEqual(robot.sitemaps, [])
         self.assertTrue(robot.allowed('/', 'agent'))
 
     def test_comments(self):


### PR DESCRIPTION
in py2, robot.sitemaps returns a list. in py3 it returns whatever comes out of map which is some kind of iter.

this pr changes it to always return a list.