### PR TITLE
Add support for running tests in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get install -y tar curl git
+RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev
+
+RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv \
+    && echo 'eval "$(pyenv init -)"' >> /root/.bash_profile
+
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/bin:/pyenv/venv/bin:$PATH
+
+RUN mkdir /pyenv
+WORKDIR /pyenv
+
+ADD .python-version .python-version
+ADD requirements.txt requirements.txt
+ADD dev-requirements.txt dev-requirements.txt
+
+RUN . ~/.bash_profile \
+    && pyenv install --skip-existing \
+    && pyenv rehash \
+    && pip install virtualenv \
+    && ([ -d venv ] || virtualenv venv) \
+    && . venv/bin/activate \
+    && pip install -r requirements.txt \
+    && pip install -r dev-requirements.txt
+
+RUN mkdir /reppy
+WORKDIR /reppy
+
+ADD . .
+
+RUN git submodule update --init --recursive
+
+CMD make test
+

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 test: reppy/robots.so
 	nosetests --with-coverage tests
 
+test-docker:
+	docker build -t reppy-tests . && docker run --rm reppy-tests
+	docker rmi reppy-tests
+
 reppy/%.so: reppy/%.py* reppy/rep-cpp/src/* reppy/rep-cpp/include/* reppy/rep-cpp/deps/url-cpp/include/* reppy/rep-cpp/deps/url-cpp/src/*
 	python setup.py build_ext --inplace
 

--- a/README.md
+++ b/README.md
@@ -181,11 +181,18 @@ Tests may be run in `vagrant`:
 make test
 ```
 
+Alternatively, they may be run in a Docker container:
+
+```bash
+make docker-test
+```
+
 Development
 ===========
 
 Environment
 -----------
+
 To launch the `vagrant` image, we only need to
 `vagrant up` (though you may have to provide a `--provider` flag):
 
@@ -202,11 +209,24 @@ make test
 
 Running Tests
 -------------
+
+### Vagrant
+
 Tests are run with the top-level `Makefile`:
 
 ```bash
 make test
 ```
+
+### Docker
+
+To use Docker to run the tests, you only need to run `make test-docker` on your local machine:
+
+```bash
+make test-docker
+```
+
+This will build an image, run the tests in a container, then delete the container and image.
 
 PRs
 ===


### PR DESCRIPTION
While working on #119 I had issues pulling the Vagrant box, so I decided to simplify things by using Docker.

This adds PR a `test-docker` rule to the `Makefile` which builds a container and runs the tests in it before deleting it.