### PR TITLE
Fix broken Cython compilation due to baked C++ files

### DIFF
--- a/reppy/robots.pyx
+++ b/reppy/robots.pyx
@@ -1,4 +1,5 @@
 # cython: linetrace=True
+# cython: language=c++
 # distutils: define_macros=CYTHON_TRACE=1
 
 from contextlib import closing

--- a/setup.py
+++ b/setup.py
@@ -34,26 +34,36 @@ ext_files = [
     'reppy/rep-cpp/deps/url-cpp/src/psl.cpp'
 ]
 
+ext_opts = dict(
+    language='c++',
+    extra_compile_args=['-std=c++11'],
+    include_dirs=[
+        'reppy/rep-cpp/include',
+        'reppy/rep-cpp/deps/url-cpp/include'
+    ]
+)
+
+
 kwargs = {}
 
 try:
     from Cython.Distutils import build_ext
     print('Building from Cython')
-    ext_files.append('reppy/robots.pyx')
+    from Cython.Build import cythonize
+
+    # ensure any baked C++ code is cleaned
+    extra = ['reppy/robots.pyx']
+    ext_files += extra
+
+    for file in extra:
+        cythonize(file, force=True, language=ext_opts["language"])
     kwargs['cmdclass'] = {'build_ext': build_ext}
+
 except ImportError:
     print('Building from C++')
     ext_files.append('reppy/robots.cpp')
 
-ext_modules = [
-    Extension(
-        'reppy.robots', ext_files,
-        language='c++',
-        extra_compile_args=['-std=c++11'],
-        include_dirs=[
-            'reppy/rep-cpp/include',
-            'reppy/rep-cpp/deps/url-cpp/include'])
-]
+ext_modules = [Extension('reppy.robots', ext_files, **ext_opts)]
 
 setup(
     name='reppy',


### PR DESCRIPTION
Having C++ files for users without Cython is nice, but when people actually use Cython it introduces multiple things:
* incompatibilities on Cython version change
* out-dated generated code which is by default **skipped** in the cythonization step as there already is a generated file (thus requires `--force` without a relevant reason in this case)
* if **anything** changes in an upstream (dependency, CPython, etc), people can't just tell `pip` to utilize source code because the source code is already broken by the generated code even if the repo itself already contains a fix

What's happening is basically this:
* on the first hash the repo is without change, thus you'll get just C++ error due to missing symbol
* on the second hash, the state is after the unsuccessful compilation and it can be seen that the C++ code was untouched
* on the third hash the generated file is removed, thus cythonization + C++ compilation proceeds as it should
* on the fourth hash a dumbed-down patch was utilized, cythonization overwrote the C++ file and C++ compilation succeeded

```bash
docker run -it python:alpine /bin/sh -c '
    apk add git g++ && \
    git clone https://github.com/seomoz/reppy && \
    cd reppy && \
    git submodule update --init --recursive && \
    git status && \
    pip install cython && \
    sha256sum reppy/robots.cpp >> /hashes.txt && \
    pip install -v -e . || \
    sha256sum reppy/robots.cpp >> /hashes.txt && \
    git clean -dxf && \
    git status && \
    rm reppy/robots.cpp && \
    pip install -v -e . && \
    sha256sum reppy/robots.cpp >> /hashes.txt && \
    pip uninstall -y reppy && \
    git clean -dxf && \
    git status && \
    sed -i -e "43i\ \ \ \ from Cython.Build import cythonize as c;c(ext_files[-1], force=True,language=\"c++\")" setup.py && \
    git diff > diff.txt && cat diff.txt && rm diff.txt && \
    pip install -v -e . && \
    sha256sum reppy/robots.cpp >> /hashes.txt && \
    cat /hashes.txt' |tee reppy-output.txt
```

This *might* have implications on caching of the result when *developing* the package when having multiple files, however since there is pretty much a single `.pyx` file I believe this implication is redundant and the overall dev-experience improves by having a straightforward solution.

Attached is the `tee`-d output: [reppy-output.txt](https://github.com/seomoz/reppy/files/7288657/reppy-output.txt)

Closes #122 